### PR TITLE
Dockerfile refresh for v0.9.0

### DIFF
--- a/.github/codefresh.yml
+++ b/.github/codefresh.yml
@@ -1,5 +1,10 @@
 version: '1.0'
 steps:
+  main_clone:
+    title: Cloning main repository...
+    type: git-clone
+    repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
+    revision: '${{CF_REVISION}}'
   BuildingDockerImage:
     title: Building Docker Image
     type: build
@@ -12,14 +17,12 @@ steps:
     image: '${{BuildingDockerImage}}'
     working_directory: IMAGE_WORK_DIR
     entry_point:
-      - /bin/sh
+      - /bin/bash
       - /codefresh/volume/cf-generated/unit_test_script
     create_file:
       path: /codefresh/volume/cf-generated
       name: unit_test_script
       content: >-
-        /bin/bash -c "
-
         source activate deepbedmap
 
         pipenv run python -m ipykernel install --user --name deepbedmap
@@ -29,7 +32,6 @@ steps:
         pipenv run python -m pytest --verbose --disable-warnings --nbval
         test_ipynb.ipynb
 
-        "
     on_success:
       metadata:
         set:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN cd /tmp && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
     conda clean --all --yes && \
     rm -rf /home/${NB_USER}/.cache/yarn && \
-    ln -s $CONDA_DIR/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate" >> ~/.bashrc
+    $CONDA_DIR/bin/conda init --verbose
 
 # Setup $HOME directory with correct permissions
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,18 @@ RUN adduser --disabled-password \
 # Setup conda
 ENV CONDA_DIR /opt/conda
 ENV NB_PYTHON_PREFIX ${CONDA_DIR}
-ENV MINICONDA_VERSION 4.5.12
+ENV MINICONDA_VERSION 4.6.14
 ENV PATH ${CONDA_DIR}/bin:$HOME/.local/bin:${PATH}
 
 RUN cd /tmp && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "866ae9dff53ad0874e1d1a60b1ad1ef8 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
+    echo "718259965f234088d785cad1fbd7de03 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \
     $CONDA_DIR/bin/conda config --system --set auto_update_conda false && \
     $CONDA_DIR/bin/conda config --system --set show_channel_urls true && \
-    conda clean -tipsy && \
+    conda clean --all --yes && \
     rm -rf /home/${NB_USER}/.cache/yarn && \
     ln -s $CONDA_DIR/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.bashrc && \
@@ -45,7 +45,7 @@ SHELL ["/bin/bash", "-c"]
 # Install dependencies in environment.yml file using conda
 COPY environment.yml ${HOME}
 RUN conda env create -n deepbedmap -f environment.yml && \
-    conda clean -tipsy && \
+    conda clean --all --yes && \
     conda list -n deepbedmap
 
 # Install Generic Mapping Tools binary from source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic@sha256:b8ba77ee12f1e3943050b8a9eb4d671ddc78a2ade6bf481029de0dd4f29f2a7b
+FROM buildpack-deps:bionic@sha256:59661846ab0c581272f4b4688702617e6cc83ef1a9ae1cf918978126babbc858
 LABEL maintainer "https://github.com/weiji14"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
@@ -49,7 +49,7 @@ RUN conda env create -n deepbedmap -f environment.yml && \
     conda list -n deepbedmap
 
 # Install Generic Mapping Tools binary from source
-ENV GMT_COMMIT_HASH 2f1f82999ff9ee9b892c83c22324d2ea7a12c76e
+ENV GMT_COMMIT_HASH 20c95aff295964a99f1e738ff371bc7323ce4421
 ENV INSTALLDIR ${HOME}/gmt
 ENV COASTLINEDIR ${INSTALLDIR}/coast
 


### PR DESCRIPTION
Keeping our base Dockerfile dependencies up to date. Also, now that [conda 4.6](https://www.anaconda.com/conda-4-6-release/) is properly released in the [miniconda package archives](https://repo.continuum.io/miniconda/), it's a good time to refactor some conda related installation scripts! ~~Can we once and for all replace `source activate` with `conda activate` now that `conda init` works? What might `conda run` bring in terms of functionality? We'll see!~~ Nope...

TODO:
- [x] Update base image [buildpack-deps:bionic](https://github.com/docker-library/buildpack-deps/tree/master/bionic) version (1a288e1fc7b4c1d2159082dde4936dcc9a35f7f6)
- [x] Update [gmt](https://github.com/GenericMappingTools/gmt) version (1a288e1fc7b4c1d2159082dde4936dcc9a35f7f6)
- [x] Update to [conda 4.6.14](https://github.com/conda/conda/releases/tag/4.6.14) (f8493599231ad75928c66d65c665018d8ee3f1e5)
- [x] Refactor dockerfile to make use of new conda>=4.6 `conda init` functionality (5983f8e075547165db1e62d8273ee7a46583b9cd)
- [x] Update codefresh CI script to use ~~`conda activate` or `conda run`?~~ /bin/bash entrypoint (10833611667f5c3ed61ce42c14c192c6e24f60fe)
- [ ] ~~Installation instructions update on main README.md?~~