### PR TITLE
Conda refresh for v0.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN adduser --disabled-password \
 # Setup conda
 ENV CONDA_DIR ${HOME}/.conda
 ENV NB_PYTHON_PREFIX ${CONDA_DIR}
-ENV MINICONDA_VERSION 4.6.14
+ENV MINICONDA_VERSION 4.7.10
 ENV PATH ${CONDA_DIR}/bin:$HOME/.local/bin:${PATH}
 
 RUN cd /tmp && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "718259965f234088d785cad1fbd7de03 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
+    echo "1c945f2b3335c7b2b15130b1b2dc5cf4 *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
     /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
     rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
     $CONDA_DIR/bin/conda config --system --prepend channels conda-forge && \

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - hcc::cuda_driver=410.73[md5=941787b750b372f4a240287634589d24]
   - anaconda::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
   - conda-forge/label/dev::gmt=6.0.0rc1[md5=983ab0490b3ea8789136267cd7e7ed02]
-  - pip=18.1[md5=d68c7e5109ba0bf4b1cfe60f0f47870a]
+  - conda-forge::pip=19.2.1[md5=95e1564d40edda4b98171de82ceba8ab]
   - conda-forge::python=3.6.7[md5=787937284685efaaa233453b49a9e719]
   - conda-forge::libspatialindex=1.9.0[md5=ef8f25a228de3a0dc716566b8d3de593]
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - hcc::cuda_driver=410.73[md5=941787b750b372f4a240287634589d24]
-  - defaults::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
+  - anaconda::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
   - conda-forge/label/dev::gmt=6.0.0rc1[md5=983ab0490b3ea8789136267cd7e7ed02]
   - pip=18.1[md5=d68c7e5109ba0bf4b1cfe60f0f47870a]
   - conda-forge::python=3.6.7[md5=787937284685efaaa233453b49a9e719]

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - hcc::cuda_driver=410.73[md5=941787b750b372f4a240287634589d24]
   - anaconda::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
-  - conda-forge/label/dev::gmt=6.0.0rc1[md5=983ab0490b3ea8789136267cd7e7ed02]
+  - conda-forge/label/dev::gmt=6.0.0rc3[md5=5dd95d211fff2434e792dac514063721]
   - conda-forge::pip=19.2.1[md5=95e1564d40edda4b98171de82ceba8ab]
   - conda-forge::python=3.6.7[md5=787937284685efaaa233453b49a9e719]
   - conda-forge::libspatialindex=1.9.0[md5=ef8f25a228de3a0dc716566b8d3de593]


### PR DESCRIPTION
Upgrading miniconda to version 4.7 that should make things [faster](https://www.anaconda.com/how-we-made-conda-faster-4-7/), and taking the opportunity to upgrade various conda dependencies in the environment.yml file.

TODO:
- [x] Update miniconda from 4.6.14 to [4.7.10](https://github.com/conda/conda/releases/tag/4.7.10) (7f17c8bafde457d6d17b862b543dd34a5b504343)
- [x] Update pip from 18.1 to [19.2.1](https://github.com/pypa/pip/releases/tag/19.2.1) (ab8b22706929e86d0eebf90248f8628d331950ca)
- [x] Update gmt from 6.0.0rc1 to [6.0.0rc3](https://github.com/GenericMappingTools/gmt/releases/tag/6.0.0rc3) (cad756a0e121ecd5f22b71b8045706ef4f9e7cc4)
- ~~Update python from 3.6.7 to 3.7.3?? (dependent on [onnx-chainer](https://github.com/chainer/onnx-chainer) 1.5.0 release)~~