### PR TITLE
Conda refresh for v1.0.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - anaconda::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
   - conda-forge::gmt=6.0.0[md5=8ff88c21814f6233560ee9bca71974ba]
   - conda-forge::pip=19.2.1[md5=f607b2d79d7c31147699e57687c227c3]
+  - conda-forge::pipenv=2020.6.2[md5=aad127c32e89991f7ded9bff0b001acb]
   - conda-forge::python=3.7.3[md5=e9385633516bf38da68e983b4f8b9e2a]
   - conda-forge::libspatialindex=1.9.0[md5=073f205d9ec981d11350e568b0ea4120]
-  - pip:
-    - pipenv==2018.11.26

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - hcc::cuda_driver=410.73[md5=941787b750b372f4a240287634589d24]
+  - hcc::cuda_driver=440.64[md5=e4ef4b596150890918e5ffbb19274d0c]
   - anaconda::cudatoolkit=10.0[md5=4388ad6015992501b042eea5197eb447]
   - conda-forge::gmt=6.0.0[md5=8ff88c21814f6233560ee9bca71974ba]
   - conda-forge::pip=19.2.1[md5=f607b2d79d7c31147699e57687c227c3]


### PR DESCRIPTION
With so many things having happened, it feels like a long time ago since I've touched this repository. Time to sparingly update some packages to keep them working smoothly!

Note: Only updating cuda driver to 440.64 while keeping cudatoolkit at 10.0, because newer drivers remain backward compatible with old cudatoolkits, as mentioned in 4dd92c8f29b007619ca905a338ffb7050f5157ec.

TODO:
- [x] Update [pipenv](https://github.com/pypa/pipenv) from 2018.11.26 to [2020.6.2](https://github.com/pypa/pipenv/releases/tag/v2020.6.2) (bf90032495a2487cbffacaa73cca0f3a52da8b82)
- [x] Update [cuda_driver](https://anaconda.org/HCC/cuda_driver) from 410.73 to 440.64 (96af71e8f0cfc965b3af7efd1b47c4316e082df6)
- ~~Update [cudatoolkit](https://anaconda.org/anaconda/cudatoolkit) from 10.0 to 10.1~~
