### PR TITLE
LaTeX and Python code to reproduce Author Comments

### DIFF
--- a/paper/author_comments_1.tex
+++ b/paper/author_comments_1.tex
@@ -1,0 +1,169 @@
+% Response to Martin Siegert's comments
+% \documentclass[tc, manuscript]{copernicus}
+% \usepackage{graphicx}
+% \usepackage{xcolor}
+%
+%
+%\begin{document}
+
+\noindent{\bf General comments}
+
+\begin{quote}
+\color{blue}
+  I very much enjoyed looking at this paper.
+  Using neural networks (and ai) to better depict the shape of the Antarctic bed is a great idea, and I applaud this effort.
+
+  The authors have done a good job in describing their work, and its potential significance, and I think it should be published in the Cryosphere with some moderate changes first necessary.
+
+  I like that this paper represents a new approach to studying the bed landscape in Antarctica and for that reason it should be a valuable asset for future work.
+
+  There are a few ways it can be improved, however - and I note my comments in the attached pdf.
+\end{quote}
+
+We would like to thank the reviewer for their feedback, and for recognizing the significance of this work on applying Deep Learning to the Cryospheric domain.
+Some interesting comments have been raised on the output and inner workings of the model, and we will respond to each individual comment in depth below.
+It is nice to see that we are in agreement on several ideas, and that there is a clear path towards what is needed in terms of data collection to improve the next generation model.
+
+\bigskip
+\noindent{\bf Specific comments}
+
+\begin{quote}
+\color{blue}
+  1. some discussion on the fact that Deepbed seems to be rougher than the base data.
+\end{quote}
+
+Correct, the DeepBedMap DEM does appear to be rougher than the base data (groundtruth) in Fig. 6 of the manuscript, and also in general, but this roughness is also something that can be adjusted by tweaking the training regime.
+The DeepBedMap neural network model works by minimizing the elevation error between the groundtruth DEM and the predicted DeepBedMap DEM.
+So the main product is bed elevation, with roughness being a secondary statistic derived from this generated bed elevation.
+It is certainly possible to incorporate roughness (or any other statistical measure) into the loss function, to yield the desired surface, and this will be explored in future work.
+
+\begin{quote}
+\color{blue}
+  2. how roughness anisotropy is captured, as this is known to occur and should be critical to more accurate modelling.
+\end{quote}
+
+Bed roughness anisotropy is indeed an important consideration, and a good example is shown by \citet{HolschuhLinkingpostglaciallandscapes2020} who used swath radar to characterize elongated features (e.g. crag and tails) at the subglacial landscape of two sites in Thwaites Glacier.
+We illustrate this over the same Thwaites Glacier region here in Fig 1, which shows DeepBedMap is able to capture aspects of the bed anisotropy from the groundtruth grid it was trained on (ice is flowing from top right to bottom left).
+
+\iffalse
+\begin{figure}[htbp]
+  \includegraphics[width=0.95\textwidth]{figure-1_thwaites_glacier_anisotropy.png}
+  \caption{
+    Comparison of bed elevation grid products over Thwaites Glacier.
+    Top - Groundtruth from gridded Operation IceBridge points.
+    Middle - DeepBedMap.
+    Bottom - BEDMAP2.
+  }
+  \label{fig:A}
+\end{figure}
+\fi
+
+The DeepBedMap model derives bed anisotropy from 1) ice flow direction from the MEaSUREs ice velocity x and y components \citep{MouginotMEaSUREsPhaseMap2019}, 2) ice surface aspect derived from the REMA ice surface \citep{HowatReferenceElevationModel2019}, and 3) the BEDMAP2 bed elevation input \citep{FretwellBedmap2improvedice2013}.
+There are therefore inherent assumptions that the topography of the current bed is associated with the current ice flow direction, surface aspect and existing BEDMAP2 anisotropy.
+Provided that the direction of this surface velocity and aspect are the same as bed roughness anisotropy, as demonstrated in \citep{HolschuhLinkingpostglaciallandscapes2020}, the neural network will be able to recognize it and perform accordingly.
+However, if the ice flow direction and surface aspect is not associated with bed anisotropy, then this assumption will be violated and the model will not perform well.
+
+\begin{quote}
+\color{blue}
+  3. how bed geology influences the roughness.
+\end{quote}
+
+While geology is linked to roughness, the training dataset does not adequately sample the distribution of different geology types over the Antarctica, nor is the the geology of Antarctica particularly well known beneath the ice.
+Ideally, we would have a training dataset that is trained on different geological domains, and though the neural network does not currently take geology as an input, we see that this can be addressed in future work.
+The main challenge lies in finding a suitable geological map (or geopotential proxy) with sufficient resolution and an adequate training dataset that covers the different lithologies.
+
+To have geology as an input variable, we would ideally need to convert it from a lithological map (categorical/qualitative) to a hardness map with an appropriate erosion law and history incorporated (quantitative).
+If the geology is given as a categorical variable (e.g. sedimentary, igneous or metamorphic), this may be harder to incorporate into neural networks that typically work with quantitative data.
+Though it is possible to train Generative Adversarial Networks on qualitative data, it would require a more elaborate model architecture and loss function.
+
+\begin{quote}
+\color{blue}
+  4. that there appear to be major gaps and to emphasize that radar is the only tool for solving this.
+\end{quote}
+
+Indeed, there is only so much we can extrapolate outside of the regions we have data for, no matter how advanced a technique we use.
+Radio echo sounding is the best tool to not only provide the background coarse resolution dataset, but also the high resolution datasets needed for training.
+Swath processing of existing datasets would be of great benefit.
+Targeted acquisition of high resolution grids over a range of bed and flow types would also be beneficial.
+
+\begin{quote}
+\color{blue}
+  5. importantly, that the approach could be better trained by working on formerly glaciated beds, such as the Laurentide ice sheet - or any land surface. Why not demonstrate the utility of the model in this way??
+\end{quote}
+
+Thank you for raising this idea.
+We have actually considered this, though our thought was to use the swath bathymetry data around Antarctica instead.
+The current model implementation does not support using solely 'elevation' as an input, as it also requires ice elevation, ice surface velocity and snow accumulation data.
+To support using these paleo-beds as training data, one could do one of the following:
+
+1. Have a paleo ice sheet model that provides these ice surface observation parameters.
+However, continent scale ice sheet models quite often produce only kilometer scale outputs, and there are inherent uncertainties with past ice sheet reconstructions that may bias the resulting trained neural network model.
+
+2. Modularize the neural network model to support different sets of training data.
+It is theoretically possible to train one main branch with just the high resolution bed elevation data, and have the separate conditional inputs as optional branches into the model.
+In fact, this main branch would simply be a Single Image Super Resolution problem, where we try to map a low resolution BEDMAP2 tile to a high resolution groundtruth image (be it from a contemporary bed, paleo bed, or offshore bathymetry).
+The supporting conditional branches would then improve on the result of this naive super resolution method, and in particular, the ice velocity input would provide information on ice flow direction.
+This modular neural network design would be more complicated to set up and train, but it will no doubt increase the available training data by at least an order of magnitude, and lead to better results.
+
+\begin{quote}
+\color{blue}
+  That said, much of these issues can be addressed in future work.
+  I still think this is a good piece of work and look forward to seeing the modified version.
+\end{quote}
+
+We hope this paper lays a foundation, and we too look forward to continuing this work and collaborating with others in the future.
+
+\bibliographystyle{copernicus}
+%\bibliography{example.bib}
+\begin{thebibliography}{4}
+\providecommand{\natexlab}[1]{#1}
+\providecommand{\url}[1]{{\tt #1}}
+\providecommand{\urlprefix}{URL }
+\expandafter\ifx\csname urlstyle\endcsname\relax
+  \providecommand{\doi}[1]{https://doi.org/\discretionary{}{}{}#1}\else
+  \providecommand{\doi}{https://doi.org/\discretionary{}{}{}\begingroup
+  \urlstyle{rm}\Url}\fi
+
+\bibitem[{Fretwell et~al.(2013)Fretwell, Pritchard, Vaughan, Bamber, Barrand,
+  Bell, Bianchi, Bingham, Blankenship, Casassa, Catania, Callens, Conway, Cook,
+  Corr, Damaske, Damm, Ferraccioli, Forsberg, Fujita, Gim, Gogineni, Griggs,
+  Hindmarsh, Holmlund, Holt, Jacobel, Jenkins, Jokat, Jordan, King, Kohler,
+  Krabill, {Riger-Kusk}, Langley, Leitchenkov, Leuschen, Luyendyk, Matsuoka,
+  Mouginot, Nitsche, Nogi, Nost, Popov, Rignot, Rippin, Rivera, Roberts, Ross,
+  Siegert, Smith, Steinhage, Studinger, Sun, Tinto, Welch, Wilson, Young,
+  Xiangbin, and Zirizzotti}]{FretwellBedmap2improvedice2013}
+Fretwell, P., Pritchard, H.~D., Vaughan, D.~G., Bamber, J.~L., Barrand, N.~E.,
+  Bell, R., Bianchi, C., Bingham, R.~G., Blankenship, D.~D., Casassa, G.,
+  Catania, G., Callens, D., Conway, H., Cook, A.~J., Corr, H. F.~J., Damaske,
+  D., Damm, V., Ferraccioli, F., Forsberg, R., Fujita, S., Gim, Y., Gogineni,
+  P., Griggs, J.~A., Hindmarsh, R. C.~A., Holmlund, P., Holt, J.~W., Jacobel,
+  R.~W., Jenkins, A., Jokat, W., Jordan, T., King, E.~C., Kohler, J., Krabill,
+  W., {Riger-Kusk}, M., Langley, K.~A., Leitchenkov, G., Leuschen, C.,
+  Luyendyk, B.~P., Matsuoka, K., Mouginot, J., Nitsche, F.~O., Nogi, Y., Nost,
+  O.~A., Popov, S.~V., Rignot, E., Rippin, D.~M., Rivera, A., Roberts, J.,
+  Ross, N., Siegert, M.~J., Smith, A.~M., Steinhage, D., Studinger, M., Sun,
+  B., Tinto, B.~K., Welch, B.~C., Wilson, D., Young, D.~A., Xiangbin, C., and
+  Zirizzotti, A.: Bedmap2: Improved Ice Bed, Surface and Thickness Datasets for
+  {{Antarctica}}, The Cryosphere, 7, 375--393, \doi{10.5194/tc-7-375-2013},
+  2013.
+
+\bibitem[{Holschuh et~al.(2020)Holschuh, Christianson, Paden, Alley, and
+  Anandakrishnan}]{HolschuhLinkingpostglaciallandscapes2020}
+Holschuh, N., Christianson, K., Paden, J., Alley, R., and Anandakrishnan, S.:
+  Linking Postglacial Landscapes to Glacier Dynamics Using Swath Radar at
+  {{Thwaites Glacier}}, {{Antarctica}}, Geology, \doi{10.1130/G46772.1}, 2020.
+
+\bibitem[{Howat et~al.(2019)Howat, Porter, Smith, Noh, and
+  Morin}]{HowatReferenceElevationModel2019}
+Howat, I.~M., Porter, C., Smith, B.~E., Noh, M.-J., and Morin, P.: The
+  {{Reference Elevation Model}} of {{Antarctica}}, The Cryosphere, 13,
+  665--674, \doi{10.5194/tc-13-665-2019}, 2019.
+
+\bibitem[{Mouginot et~al.(2019)Mouginot, Rignot, and
+  Scheuchl}]{MouginotMEaSUREsPhaseMap2019}
+Mouginot, J., Rignot, E., and Scheuchl, B.: {{MEaSUREs Phase Map}} of
+  {{Antarctic Ice Velocity}}, {{Version}} 1, \doi{10.5067/PZ3NJ5RXRH10}, 2019.
+
+\end{thebibliography}
+
+%\end{document}

--- a/paper/author_comments_2.tex
+++ b/paper/author_comments_2.tex
@@ -1,0 +1,226 @@
+% Response to Anonymous Referee #2's comments
+% \documentclass[tc, manuscript]{copernicus}
+% \usepackage{graphicx}
+% \usepackage{xcolor}
+%
+% \begin{document}
+
+\noindent{\bf General comments}
+
+\begin{quote}
+\color{blue}
+  This paper introduces a new method, based on Machine Learning, namely a Generative Adversarial Network (GAN), to add short-scale roughness to the bed of Bedmap2.
+  The paper is well written, easy to follow and well illustrated, I really enjoyed reading it.
+  I recommend publication after minor revisions.
+  My main problem while reading the manuscript was that I felt like the authors were overselling their approach and the performance of the GAN.
+\end{quote}
+
+\begin{quote}
+\color{blue}
+  What the GAN is doing is to essentially try to reintroduce basal roughness in the smooth bed of Bedmap2 based on surface features.
+  While the method is different, the goal of this study is very similar to the paper of Graham et al. 2017 (www.earth-syst-sci-data.net/9/267/2017/) or Goff et al. 2017 (https://doi.org/10.3189/2014JoG13J200), papers that are barely mentioned in the text.
+\end{quote}
+
+We thank the reviewer for their considered review and comments.
+Thank you for highlighting the work of \citet{GoffConditionalsimulationThwaites2014} and \citet{Grahamhighresolutionsyntheticbed2017}.
+In regard to the publication by \citet{Grahamhighresolutionsyntheticbed2017}, we have actually compared their Synthetic HRES product at some earlier conferences (see \citet{LeongDeepBedMapUsingdeep2019} and \citet{LeongDeepBedMapsuperresolutiondeep2019}), but decided to focus on the newer BedMachine Antarctica product for this manuscript.
+For completeness, we have now reproduced a 3D image of this Synthetic HRES product here (see Fig 1), using the same Pine Island Glacier extent in Fig. 3 of the manuscript.
+
+\iffalse
+\begin{figure}[htbp]
+  \includegraphics[width=0.95\textwidth]{figure-1_qualitative_bed_comparison.png}
+  \caption{
+    Comparison of interpolated bed elevation grid products over Pine Island Glacier.
+    a) DeepBedMap (ours) at 250 m resolution.
+    b) BEDMAP2.
+    c) Synthetic HRES product.
+    d) BedMachine Antarctica.
+  }
+  \label{fig:1}
+\end{figure}
+\fi
+
+We acknowledge that the goal of this paper is similar to the two aforementioned papers, and fall in the broad category of using spatial statistics to derive a higher spatial resolution bed.
+Specifically, the conditional simulation method applied by \citet{GoffConditionalsimulationThwaites2014} is able to resolve both fine-scale roughness and channelized morphology over the complex topography of Thwaites Glacier, and make use of the fact that roughness statistics are different between highland and lowland areas.
+\citet{Grahamhighresolutionsyntheticbed2017} uses a two-step approach to generate their synthetic HRES grid, with the high frequency roughness component coming from the ICECAP and Bedmap1 compilation radar point data, and the low frequency component coming from BEDMAP2.
+In DeepBedMap, we attempt to capture bed topography directly from gridded pixels,  while incorporating extra knowledge from satellite remote sensing datasets to fill in larger gaps between flightlines, much like in BedMachine Antarctica \citep{MorlighemDeepglacialtroughs2019}.
+Neither one method is perfect, and we see all of them as complementary.
+
+\noindent{\bf Specific comments}
+
+\begin{quote}
+\color{blue}
+  It is clearly an excellent idea to try to use these methods, established in other fields, to the mapping of the Antarctic bed.
+  It also seems natural to use surface data (velocity, SMB, etc) as a “predictor” for the shape of the bed.
+  That being said, it seems like the surface observations provided to the GAN do not make it possible to recover big features such as ridges or valleys in the bed that could have a large impact on ice flow models, but only to add some high-resolution roughness to the overly smooth bed of Bedmap2.
+\end{quote}
+
+Being able to capture both long wavelength and short wavelength bed features is the goal.
+We do however rely on the BEDMAP2 surface as a reference for this super resolution task, which limits the generated topography to within a tolerance of the surface.
+If we don't use BEDMAP2, then the modelled bed elevation could diverge significantly from the actual bed elevation.
+Ideally we would be able to run the model independent of BEDMAP2, however, this would no longer be a super resolution model.
+
+Note that the provided DeepBedMap DEM model is only one `possible' version, generated from one model training run we deemed best according to our training metric, and we may have biased our model towards resolving short wavelength features, compared to BedMachine Antarctica which recovers large scale features like ridges and valleys well.
+That is not to say we cannot combine super resolution with inversion techniques, and as mentioned in text, the DeepBedMap model architecture should be applicable to any reference bed, be it BedMachine Antarctica or the upcoming BEDMAP3.
+
+\begin{quote}
+\color{blue}
+  This is a valuable exercise and using machine learning to do this is definitely a good idea and worth publishing, but I don’t think we are there yet.
+  The training dataset is extremely small and probably not representative of all the different types of terrains under the Antarctic ice sheet (as mentioned by the authors).
+\end{quote}
+
+There is certainly more work to do on both the modelling and data collection side (see our reply to Reviewer 1).
+It should be mentioned though that bed interpolation exercises such as ours and BedMachine Antarctica help tell us where the data gaps are.
+As more datasets are gathered from targeted acquisitions, marine swath bathymetry, etc, these method will become even more powerful.
+
+\begin{quote}
+\color{blue}
+  We see a lot of artifacts in the solution and many of these artifacts are discussed in the text: dunes and missing mountains around Byrd (4h), Terraces (4i), Speckle (4a), etc.
+  In the maps of figure 4, I could not find a bed that seemed realistic.
+\end{quote}
+
+In Figure 4 of the manuscript, we have chosen to highlight different locations, some of which are unrealistic as acknowledged in the text.
+The example we provide in our reply to Reviewer 1 (see Fig. 1 there) provides an example of a realistic bed as does Fig 5e over the non-mountainous areas of Rutford Ice Stream.
+
+If we able to quantify precisely what is wrong with the generated bed topography, this can be incorporated into the Discriminator component of the Generative Adversarial Network.
+Currently we use a basic Discriminator designed for standard computer vision tasks.
+That is not to say that we cannot incorporate glaciology specific criteria such as ice flow direction into the Discriminator model design, which would push the Generator model to produce more realistic results.
+Alternatively, we can adjust the loss function weights to dampen the effects of the REMA ice surface elevation input, as our model may have overfitted to the REMA surface DEM.
+
+\begin{quote}
+\color{blue}
+  Even along the flight line of OIB (figure 6) the roughness of DeepBedMap seems exacerbated and not necessarily representative of the actual roughness measured by the radar.
+  And again, the authors make it clear, I just find the title/abstract and parts of the paper a bit misleading in the sense that I don’t think this approach achieves the objectives of this work, and that’s ok!
+  I would not say that the GAN “better resolves” the bed topography for example.
+\end{quote}
+
+We may have been overly enthusiastic in some of our language and will do our best to temper this in revision.
+In regard to roughness, our neural network model was trained by minimizing the error between the generated bed elevation and the bed elevation of the groundtruth training data, rather than the roughness parameter which is a derived statistic.
+Incorporating roughness into the loss function would be a useful exercise.
+"Better" is indeed a subjective term that is dependent on the current baseline, and we will consider using another title for the formal publication.
+
+\begin{quote}
+\color{blue}
+Another problem is that it is not straightforward to constrain the model with radar data, and this is not mentioned in the text.
+The roughness of the bed that is captured (and known) by the radar data along flightlines cannot be preserved.
+This is an important limitation.
+\end{quote}
+
+We agree that the pixel-based DeepBedMap model is unable to constrain itself easily to point-based radar data.
+The along track resolution of radar bed picks are much smaller than the 250 m pixels, and it it not easy to preserve roughness from radar unless smaller pixels are used.
+This may change once we start using swath radar data for training instead of interpolating our own grid from radar point data collected along flightlines.
+
+\begin{quote}
+\color{blue}
+  I also did not understand the paragraph line 204-205: why would we use the inferred bed under ice shelves when clearly surface features do not reflect the shape of the bathymetry?
+  It is not because the authors “can” do it that they should do it.
+\end{quote}
+
+The intention was to provide a means for others to more easily interpolate their own bathymetry grid with the DeepBedMap grid.
+There is a choice of different grounding lines, and rather than enforce one, we would prefer to let others cut and blend it with their own bathymetry dataset, smoothed out over any selected distance.
+We now intend to provide a mask file with the final product, allowing the user to apply this ice shelf mask directly, or use one of their own.
+We will also clarify this intention better in text so as not to suggest that we have managed to super resolve the under ice shelf bathymetry.
+
+\begin{quote}
+\color{blue}
+That said, much of these issues can be addressed in future work. I still think this is a good piece of work and look forward to seeing the modified version.
+\end{quote}
+
+There is always potential to improve this work further, and one that we have faced over the year developing this methodology, with better techniques and new data coming in all the time.
+Hopefully this paper can serve as a good starting point, and we are excited to see what others will come up with in the future.
+
+\noindent{\bf Technical corrections}
+
+\begin{quote}
+\color{blue}
+Other than that, the paper is easy to follow and really well written, I only found one
+typo:
+ line 297: care has been taking $\rightarrow$ taken
+\end{quote}
+
+Once again, thank you very much for your constructive feedback.
+
+\bibliographystyle{copernicus}
+\bibliography{example.bib}
+\begin{thebibliography}{7}
+\providecommand{\natexlab}[1]{#1}
+\providecommand{\url}[1]{{\tt #1}}
+\providecommand{\urlprefix}{URL }
+\expandafter\ifx\csname urlstyle\endcsname\relax
+  \providecommand{\doi}[1]{https://doi.org/\discretionary{}{}{}#1}\else
+  \providecommand{\doi}{https://doi.org/\discretionary{}{}{}\begingroup
+  \urlstyle{rm}\Url}\fi
+
+\bibitem[{Fretwell et~al.(2013)Fretwell, Pritchard, Vaughan, Bamber, Barrand,
+  Bell, Bianchi, Bingham, Blankenship, Casassa, Catania, Callens, Conway, Cook,
+  Corr, Damaske, Damm, Ferraccioli, Forsberg, Fujita, Gim, Gogineni, Griggs,
+  Hindmarsh, Holmlund, Holt, Jacobel, Jenkins, Jokat, Jordan, King, Kohler,
+  Krabill, {Riger-Kusk}, Langley, Leitchenkov, Leuschen, Luyendyk, Matsuoka,
+  Mouginot, Nitsche, Nogi, Nost, Popov, Rignot, Rippin, Rivera, Roberts, Ross,
+  Siegert, Smith, Steinhage, Studinger, Sun, Tinto, Welch, Wilson, Young,
+  Xiangbin, and Zirizzotti}]{FretwellBedmap2improvedice2013}
+Fretwell, P., Pritchard, H.~D., Vaughan, D.~G., Bamber, J.~L., Barrand, N.~E.,
+  Bell, R., Bianchi, C., Bingham, R.~G., Blankenship, D.~D., Casassa, G.,
+  Catania, G., Callens, D., Conway, H., Cook, A.~J., Corr, H. F.~J., Damaske,
+  D., Damm, V., Ferraccioli, F., Forsberg, R., Fujita, S., Gim, Y., Gogineni,
+  P., Griggs, J.~A., Hindmarsh, R. C.~A., Holmlund, P., Holt, J.~W., Jacobel,
+  R.~W., Jenkins, A., Jokat, W., Jordan, T., King, E.~C., Kohler, J., Krabill,
+  W., {Riger-Kusk}, M., Langley, K.~A., Leitchenkov, G., Leuschen, C.,
+  Luyendyk, B.~P., Matsuoka, K., Mouginot, J., Nitsche, F.~O., Nogi, Y., Nost,
+  O.~A., Popov, S.~V., Rignot, E., Rippin, D.~M., Rivera, A., Roberts, J.,
+  Ross, N., Siegert, M.~J., Smith, A.~M., Steinhage, D., Studinger, M., Sun,
+  B., Tinto, B.~K., Welch, B.~C., Wilson, D., Young, D.~A., Xiangbin, C., and
+  Zirizzotti, A.: Bedmap2: Improved Ice Bed, Surface and Thickness Datasets for
+  {{Antarctica}}, The Cryosphere, 7, 375--393, \doi{10.5194/tc-7-375-2013},
+  2013.
+
+\bibitem[{Goff et~al.(2014)Goff, Powell, Young, and
+  Blankenship}]{GoffConditionalsimulationThwaites2014}
+Goff, J.~A., Powell, E.~M., Young, D.~A., and Blankenship, D.~D.: Conditional
+  Simulation of {{Thwaites Glacier}} ({{Antarctica}}) Bed Topography for Flow
+  Models: {{Incorporating}} Inhomogeneous Statistics and Channelized
+  Morphology, Journal of Glaciology, 60, 635--646, \doi{10.3189/2014JoG13J200},
+  2014.
+
+\bibitem[{Graham et~al.(2017)Graham, Roberts, {Galton-Fenzi}, Young,
+  Blankenship, and Siegert}]{Grahamhighresolutionsyntheticbed2017}
+Graham, F.~S., Roberts, J.~L., {Galton-Fenzi}, B.~K., Young, D., Blankenship,
+  D., and Siegert, M.~J.: A High-Resolution Synthetic Bed Elevation Grid of the
+  {{Antarctic}} Continent, Earth System Science Data, 9, 267--279,
+  \doi{10.5194/essd-9-267-2017}, 2017.
+
+\bibitem[{Leong and Horgan(2019{\natexlab{a}})}]{LeongDeepBedMapUsingdeep2019}
+Leong, W.~J. and Horgan, H.~J.: {{DeepBedMap}}: {{Using}} a Deep Neural Network
+  to Better Resolve the Bed Topography of {{Antarctica}}, in: {{EGU General
+  Assembly}}, {Vienna, Austria}, 2019{\natexlab{a}}.
+
+\bibitem[{Leong and
+  Horgan(2019{\natexlab{b}})}]{LeongDeepBedMapsuperresolutiondeep2019}
+Leong, W.~J. and Horgan, H.~J.: {{DeepBedMap}}: {{A}} Super-Resolution Deep
+  Neural Network for Resolving the Bed Topography of {{Antarctica}}, in: {{IGS
+  Five Decades}} of {{Radioglaciology Symposium}}, {Stanford, California,
+  United States}, 2019{\natexlab{b}}.
+
+\bibitem[{Morlighem(2019)}]{MorlighemMEaSUREsBedMachineAntarctica2019}
+Morlighem, M.: {{MEaSUREs BedMachine Antarctica}}, {{Version}} 1,
+  \doi{10.5067/C2GFER6PTOS4}, 2019.
+
+\bibitem[{Morlighem et~al.(2019)Morlighem, Rignot, Binder, Blankenship, Drews,
+  Eagles, Eisen, Ferraccioli, Forsberg, Fretwell, Goel, Greenbaum, Gudmundsson,
+  Guo, Helm, Hofstede, Howat, Humbert, Jokat, Karlsson, Lee, Matsuoka, Millan,
+  Mouginot, Paden, Pattyn, Roberts, Rosier, Ruppel, Seroussi, Smith, Steinhage,
+  Sun, van~den Broeke, van Ommen, van Wessem, and
+  Young}]{MorlighemDeepglacialtroughs2019}
+Morlighem, M., Rignot, E., Binder, T., Blankenship, D., Drews, R., Eagles, G.,
+  Eisen, O., Ferraccioli, F., Forsberg, R., Fretwell, P., Goel, V., Greenbaum,
+  J.~S., Gudmundsson, H., Guo, J., Helm, V., Hofstede, C., Howat, I., Humbert,
+  A., Jokat, W., Karlsson, N.~B., Lee, W.~S., Matsuoka, K., Millan, R.,
+  Mouginot, J., Paden, J., Pattyn, F., Roberts, J., Rosier, S., Ruppel, A.,
+  Seroussi, H., Smith, E.~C., Steinhage, D., Sun, B., van~den Broeke, M.~R.,
+  van Ommen, T.~D., van Wessem, M., and Young, D.~A.: Deep Glacial Troughs and
+  Stabilizing Ridges Unveiled beneath the Margins of the {{Antarctic}} Ice
+  Sheet, Nature Geoscience, \doi{10.1038/s41561-019-0510-8}, 2019.
+
+\end{thebibliography}
+
+% \end{document}

--- a/paper_figures.py
+++ b/paper_figures.py
@@ -20,6 +20,7 @@
 # Code used to produce each figure in the DeepBedMap paper.
 
 # %%
+import itertools
 import os
 import subprocess
 
@@ -658,6 +659,7 @@ fig.savefig(
 )
 fig.show()
 
+
 # %%
 
 # %% [markdown]
@@ -1103,3 +1105,111 @@ fig.savefig(fname="paper/figures/fig6_elevation_roughness_transect.eps", dpi=300
 fig.show()
 
 # %%
+
+# %% [markdown]
+# ## **Plots in Author Comments**
+#
+# At https://tc.copernicus.org/preprints/tc-2020-74/#discussion
+
+# %% [markdown]
+# ### **Figure 1 at https://doi.org/10.5194/tc-2020-74-AC2**
+#
+# Similar to Figure 3 in the preprint, but showing Synthetic HRES grid
+# from https://doi.org/10.4225/15/57464ADE22F50
+
+# %%
+fig = gmt.Figure()
+deepbedmap.subplot(
+    directive="begin", row=2, col=2, A="+jCT+o-4c/-5c", Fs="9c/9c", M="2c/3c"
+)
+deepbedmap.plot_3d_view(
+    fig=fig,
+    img="model/deepbedmap3.nc",  # DeepBedMap
+    ax=(0, 0),
+    zmin=-1400,
+    title="a) DeepBedMap",  # ours
+    zlabel="Bed elevation (metres)",
+)
+deepbedmap.plot_3d_view(
+    fig=fig,
+    img="model/cubicbedmap.nc",  # BEDMAP2
+    ax=(0, 1),
+    zmin=-1400,
+    title="b) BEDMAP2",
+    zlabel="Bed elevation (metres)",
+)
+deepbedmap.plot_3d_view(
+    fig=fig,
+    img="model/synthetichr.nc",  # Synthetic HRES
+    ax=(1, 0),
+    zmin=-1400,
+    title="c) Synthetic HRES",
+    zlabel="Bed elevation (metres)",
+)
+deepbedmap.plot_3d_view(
+    fig=fig,
+    img="model/bedmachinea.nc",  # BedMachine Antarctica
+    ax=(1, 1),
+    zmin=-1400,
+    title="d) BedMachine",
+    zlabel="Bed elevation (metres)",
+)
+deepbedmap.subplot(directive="end")
+fig.savefig(
+    fname="paper/figures/figure-1_qualitative_bed_comparison.png", dpi=300, crop=False
+)
+fig.show()
+
+# %% [markdown]
+# ### **Figure 1 of https://doi.org/10.5194/tc-2020-74-AC3**
+#
+# Plots over upstream and downstream parts of Thwaites Glacier
+#
+# See also Holschuh, N., Christianson, K., Paden, J., Alley, R. B., & Anandakrishnan, S. (2020).
+# Linking postglacial landscapes to glacier dynamics using swath radar at Thwaites Glacier, Antarctica. Geology.
+# https://doi.org/10.1130/G46772.1
+
+# %%
+#!gmt grdcut model/deepbedmap3_big_int16.tif -Gdeepbedmap3_thwaites_int16.tif -R-1435000/-1275000/-475000/-432500
+gridDict = {
+    "Groundtruth": "highres/20xx_Antarctica_TO.nc",
+    "DeepBedMap": "model/deepbedmap3_thwaites.nc",
+    # "BedMachine": "model/BedMachineAntarctica_2019-11-05_v01.nc",
+    "BEDMAP2": "lowres/bedmap2_bed.tif",
+}
+fig = gmt.Figure()
+deepbedmap.subplot(
+    directive="begin", row=3, col=1, A="+jLT+gwhite", B="WSne", Bx="fg", By="f", Fs="8c"
+)
+region = [-1435000, -1275000, -475000, -432500]
+for i, (name, grid) in enumerate(gridDict.items()):
+    print(i, name, grid)
+    deepbedmap.subplot(directive="set", row=i, col=0, A=f'"{name}"')
+    gmt.makecpt(cmap="oleron", series=[-1500, -500])
+    fig.grdimage(
+        grid=grid,
+        region=region,
+        projection="x1:500000",
+        cmap=True,
+        shading="+d",
+        Q=True,
+    )
+    fig.colorbar(
+        region=region,
+        projection="x1:500000",
+        position="JMR+w6.0c/0.3c+v",
+        box="+gwhite+p0.5p",
+        frame=["af", 'x+l"Elevation"', "y+lkm"],
+        cmap="+Uk",  # kilo-units, i.e. divide by 1000
+        S=True,  # no lines inside color scalebar
+    )
+    fig.basemap(
+        region=[r / 1000 for r in region],
+        projection="x1:500",
+        frame="WSne",
+        Bx='af50g+l"Polar Stereographic X (km)"' if i == 2 else False,
+        By='af50g+l"Polar Stereographic Y (km)"',
+    )
+deepbedmap.subplot(directive="end")
+fig.savefig(fname=f"paper/figures/figure-1_thwaites_glacier_anisotropy.png", dpi=300)
+fig.show()


### PR DESCRIPTION
The LaTeX code for the author comments in reply to the reviewer comments, and the Python code to reproduce the figures, if anyone needs them! This is for ['The Cryosphere'](https://tc.copernicus.org), but should be valid for just about any Copernicus Publications journals (I guess). Actual published versions are at https://doi.org/10.5194/tc-2020-74-AC3 and https://doi.org/10.5194/tc-2020-74-AC2 (long story on what happened to AC1). Should have published this earlier but better late than never!